### PR TITLE
Fix deprecations in tax extractor

### DIFF
--- a/src/helpers/TaxExtractor.php
+++ b/src/helpers/TaxExtractor.php
@@ -34,8 +34,8 @@ class TaxExtractor
 	public function __construct(LineItem $line)
 	{
 		$this->line = $line;
-		$this->included = $line->getAdjustmentsTotalByType('tax', true);
-		$this->excluded = $line->getAdjustmentsTotalByType('tax', false);
+		$this->included = $line->getTaxIncluded();
+		$this->excluded = $line->getTax();
 	}
 
 	/**


### PR DESCRIPTION
This used to be the right way to do things at v2.0, but getAdjustmentsTotalByType was deprecated in Commerce 2.2, and getTax and getTaxIncluded were un-deprecated.